### PR TITLE
CBL-4525: XCode 14.3 iOS build error fix

### DIFF
--- a/ExceptionUtils.m
+++ b/ExceptionUtils.m
@@ -207,7 +207,7 @@ bool MYIsDebuggerAttached(void)
 
 
 #if !TARGET_CPU_X86_64 && !TARGET_CPU_X86
-void _MYBreakpoint() {
+void _MYBreakpoint(void) {
     pthread_kill(pthread_self(), SIGINT);
 }
 #endif

--- a/MYLogging.h
+++ b/MYLogging.h
@@ -60,7 +60,7 @@ typedef struct MYLogDomain {
 
     #define DefineLogDomain(DOMAIN) \
         MYLogDomain DOMAIN##_LogDomain = {(MYLogLevel)255, #DOMAIN}; \
-        __attribute__((constructor)) static void register_##DOMAIN##_LogDomain() \
+        __attribute__((constructor)) static void register_##DOMAIN##_LogDomain(void) \
             { DOMAIN##_LogDomain.next = gMYLogDomainList; gMYLogDomainList = &DOMAIN##_LogDomain; }
 
 

--- a/MYLogging.m
+++ b/MYLogging.m
@@ -44,7 +44,7 @@ static MYLogLevel enableLogTo(NSString *domain, MYLogLevel level);
 static MYLoggingTo loggingMode(void);
 
 
-static void InitLogging() {
+static void InitLogging(void) {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         @autoreleasepool {
@@ -142,7 +142,7 @@ MYLogLevel EnableLogTo(NSString *domain, MYLogLevel level) {
 #endif
 
 
-NSArray* AllLogDomains() {
+NSArray* AllLogDomains(void) {
     NSMutableArray* names = $marray();
     for (MYLogDomain* domain = gMYLogDomainList; domain; domain = domain->next) {
         if (domain != &MYDefault_LogDomain)
@@ -185,7 +185,7 @@ static MYLoggingTo getLoggingMode(int fd ) {
 #endif
 }
 
-static MYLoggingTo loggingMode() {
+static MYLoggingTo loggingMode(void) {
     static MYLoggingTo sMode;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{


### PR DESCRIPTION
`A function declaration without a prototype is deprecated in all versions of C`